### PR TITLE
Error checker util

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pocketgems/unit-test",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "description": "A thin wrapper around Jest and Supertest to provide better organization",
     "main": "src/test.js",
     "scripts": {

--- a/src/test.js
+++ b/src/test.js
@@ -2,6 +2,12 @@ if (Number(process.env.INDEBUGGER)) {
   jest.setTimeout(30 * 60 * 1000)
 }
 
+/**
+ * Helper error when attempting to examine contents of a given error.
+ * Should be used in conjunction with BaseServiceTest.prototype.getError
+ */
+class NoErrorThrownError extends Error {}
+
 class BaseTest {
   _listTestsOn (obj) {
     return Object.getOwnPropertyNames(obj).filter(name => {
@@ -40,6 +46,25 @@ class BaseTest {
   async afterAll () {}
   async beforeEach () {}
   async afterEach () {}
+
+   /**
+   * Catches error from specified call. Error may be examined by calling
+   * tests.
+   * This approach is recommended for in-depth assertions on errors:
+   * https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-conditional-expect.md#how-to-catch-a-thrown-error-for-testing-without-violating-this-rule
+   * @param {Promise} call - function expected to throw
+   * @throws {NoErrorThrownError} - exception if 'call' method
+   * does not throw.
+   * @returns {Error} error thrown be inner call method.
+   */
+   async catchError (call) {
+    try {
+      await call()
+    } catch (error) {
+      return error
+    }
+    throw new NoErrorThrownError()
+  }
 
   runTests () {
     describe(this.constructor.name, () => {

--- a/test/unit-test-example.js
+++ b/test/unit-test-example.js
@@ -9,6 +9,17 @@ class ExampleTest extends BaseTest {
   testInvalidCall () {
     expect(() => Example.broken()).toThrow()
   }
+
+  async testCatchError () {
+    const shouldThrow = () => {
+      throw new Error('hello!')
+    }
+    const error = await this.catchError(shouldThrow)
+    expect(error.message).toEqual('hello!')
+    const doesNotThrow = () => 2
+    await expect(this.catchError(doesNotThrow))
+      .rejects.toThrow()
+  }
 }
 
 runTests(ExampleTest)

--- a/test/unit-test-example.js
+++ b/test/unit-test-example.js
@@ -1,6 +1,13 @@
 const { Example } = require('../example/feature')
 const { BaseTest, runTests } = require('../src/test')
 
+class CustomError extends Error {
+  constructor(message, customData) {
+    super(message)
+    this.customData = customData
+  }
+}
+
 class ExampleTest extends BaseTest {
   testMultiply () {
     expect(Example.multiply(2, 3)).toBe(6)
@@ -12,10 +19,18 @@ class ExampleTest extends BaseTest {
 
   async testCatchError () {
     const shouldThrow = () => {
-      throw new Error('hello!')
+      throw new CustomError('hello!', {
+        a: 33,
+        b: [1,2]
+      })
     }
     const error = await this.catchError(shouldThrow)
+    expect(error).toBeInstanceOf(CustomError)
     expect(error.message).toEqual('hello!')
+    expect(error.customData).toEqual({
+      a: 33,
+      b: [1,2]
+    })
     const doesNotThrow = () => 2
     await expect(this.catchError(doesNotThrow))
       .rejects.toThrow()


### PR DESCRIPTION
# Change Log
- Adding util method for catching errors. Useful for examining errors more closely, where `expect(...).toThrow` may only check message and class type.

# Checklist
- I confirm there is no private key, token, secret, etc. added in this pull request or any intermediate commits, as they will become publicly accessible and result in security breach.
- By submitting this pull request to Pocket Gems' Github repository, I confirm that Pocket Gems can use, modify, copy and redistribute my contribution, under the terms of Pocket Gems' choice, which as of date of this submission, shall be the Apache License Version 2.0, and may be changed at any time at Pocket Gems' sole discretion.
